### PR TITLE
Explicitly use `bash` shell

### DIFF
--- a/dockerveth.sh
+++ b/dockerveth.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright (c) 2017 Micah Culpepper
 #


### PR DESCRIPTION
Otherwise the script will not work when `/bin/sh` is not actually linked to `bash`