### PR TITLE
Fix script with multiple networks

### DIFF
--- a/dockerveth.sh
+++ b/dockerveth.sh
@@ -101,8 +101,8 @@ get_container_if_indices () {
     ils=$(ip netns exec "ns-${c_pid}" ip link show type veth)
     indices=""
     for line in $ils; do
-        m1="${ils%%:*}"
-        m2="${ils%% *}"
+        m1="${line%%:*}"
+        m2="${line%% *}"
         if [ "${m1}:" = "$m2" ]; then
             indices="${indices}${m1}${NL}"
         fi


### PR DESCRIPTION
Thanks for this incredibly helpful tool, I use it a lot.
I noticed it seems to be broken when using Docker Swarm and is a bit unreliable in general with multiple networks.

Also, I'm using branch `develop`.

I found and fixed a bug in the `get_container_if_indices` function. This PR seems to make the script work with Docker Swarm again.

Suppose you have this `ip netns` output:
```
3902: eth0@if3903: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP mode DEFAULT group default 
    link/ether 02:42:07:00:00:4d brd ff:ff:ff:ff:ff:ff link-netnsid 0
3904: eth1@if3905: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DEFAULT group default 
    link/ether 02:42:ac:12:00:03 brd ff:ff:ff:ff:ff:ff link-netnsid 1
```

Then, `get_container_if_indices` (which is supposed to extract the interface indices at the start of each line) outputs `3902<NL>3902<NL>3902<NL>3902<NL>`.
Effectively, this makes the script only work for the first network.

As expected, the script fails to find VETHs on my Docker Swarm network:

```
CONTAINER ID    VETH            NAMES
03ebfc356730    not_found       devnet_validator.3.1xshab2ugxmxd2f62cplbs71i
5f830b23c128    not_found       devnet_validator.4.xpkq67ow2fplm7t0lmzeaolz6
e2da2b20d97f    not_found       devnet_validator.2.kszne59aycq41j4izimktimkm
054bedcfbfbf    not_found       devnet_validator.1.ihxidms8bcfhh42bxja4d5q19
5038459c90e7    veth9d2ee74     devnet_seed-list
0f9cff4aea0b    veth4444335     devnet_staking
ba3b74fb70b3    not_found       devnet_seed
```

I narrowed down the bug to lines 104-105, where the wrong variable gets used for parsing. In short, it parses the entire `netns` output again and again, instead of parsing each loop.

With the bug fixed, `get_container_if_indices` has the correct output: `3902<NL>3904<NL>`.

Finally, `dockerveth.sh` produces the correct output:

```
CONTAINER ID    VETH            NAMES
03ebfc356730    veth05d8351     devnet_validator.3.1xshab2ugxmxd2f62cplbs71i
5f830b23c128    veth9d1ddc3     devnet_validator.4.xpkq67ow2fplm7t0lmzeaolz6
e2da2b20d97f    vethafdea1a     devnet_validator.2.kszne59aycq41j4izimktimkm
054bedcfbfbf    vethde7169a     devnet_validator.1.ihxidms8bcfhh42bxja4d5q19
5038459c90e7    veth9d2ee74     devnet_seed-list
0f9cff4aea0b    veth4444335     devnet_staking
ba3b74fb70b3    vethf77884e     devnet_seed
```